### PR TITLE
Refactored test_bottom_n_counters function from CI Lab (Task 2.1)

### DIFF
--- a/gen_ai/task2.1/RileyRamos_refactor_code.py
+++ b/gen_ai/task2.1/RileyRamos_refactor_code.py
@@ -1,0 +1,34 @@
+from http import HTTPStatus
+
+def test_bottom_n_counters(self, client):
+    """It should return the bottom N lowest counters"""
+    
+    # Reset and initialize counters in a structured way
+    client.post('/counters/reset')
+    for counter in ['a', 'b']:
+        client.post(f'/counters/{counter}')
+
+    # Test fetching the single lowest counter
+    response = client.get('/counters/bottom/1')
+    assert response.status_code == HTTPStatus.OK
+    
+    json_data = response.get_json()
+    assert isinstance(json_data, dict), "Response should be a dictionary"
+    
+    # Ensure that there is only one result, and it has the expected value
+    assert len(json_data) == 1, "Should return exactly one counter"
+    assert min(json_data.values()) == 0, "Lowest counter value should be 0"
+    
+    # Test fetching the bottom 2 counters
+    response = client.get('/counters/bottom/2')
+    assert response.status_code == HTTPStatus.OK
+
+    json_data = response.get_json()
+    assert isinstance(json_data, dict), "Response should be a dictionary"
+    
+    # Ensure 'b' is in the bottom 2 counters
+    assert 'b' in json_data, "'b' should be in the returned bottom 2 counters"
+
+    # Verify that counters are sorted in ascending order
+    sorted_values = list(json_data.values())
+    assert sorted_values == sorted(sorted_values), "Counters should be sorted in ascending order"


### PR DESCRIPTION
Closes [#69](https://github.com/onasito/Group-5/issues/69)  by using a loop to initialize counters and adding meaningful error messages, ensuring that the code is more readable and robust. Also clearly separates setup, execution, and validation, making the function easier to expand in the future. 

ChatGPT Reasoning: [https://chatgpt.com/share/67c2443b-1d08-8009-b937-fcee6f760ece](https://chatgpt.com/share/67c2443b-1d08-8009-b937-fcee6f760ece) 